### PR TITLE
ci: increase postgres max_connections limit to 200

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,10 +104,14 @@ jobs:
           filters: |
             openapi:
               - 'openapi/*.yaml'
+      - name: Show initial max_connections value
+        run: docker exec -i kas-fleet-manager-db /bin/bash docker-entrypoint.sh psql -U kas_fleet_manager -d serviceapitests -c 'show max_connections;'
       - name: Increase Postgres max_connections limit
         run: docker exec -i kas-fleet-manager-db /bin/bash docker-entrypoint.sh psql -U kas_fleet_manager -d serviceapitests -c 'alter system set max_connections=200;'
       - name: Restart Postgres container
         run: docker restart --time 0 kas-fleet-manager-db
+      - name: Show max_connections after new configuration has been applied
+        run: docker exec -i kas-fleet-manager-db /bin/bash docker-entrypoint.sh psql -U kas_fleet_manager -d serviceapitests -c 'show max_connections;'
       - name: Setup Keycloak realm config
         run: make sso/config
       - name: Cache go module

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --name kas-fleet-manager-db
 
       keycloak:
         image: quay.io/keycloak/keycloak:17.0.1-legacy
@@ -103,6 +104,10 @@ jobs:
           filters: |
             openapi:
               - 'openapi/*.yaml'
+      - name: Increase Postgres max_connections limit
+        run: docker exec -i kas-fleet-manager-db /bin/bash docker-entrypoint.sh psql -U kas_fleet_manager -d serviceapitests -c 'alter system set max_connections=200;'
+      - name: Restart Postgres container
+        run: docker restart --time 0 kas-fleet-manager-db
       - name: Setup Keycloak realm config
         run: make sso/config
       - name: Cache go module

--- a/scripts/local_db_setup.sh
+++ b/scripts/local_db_setup.sh
@@ -18,4 +18,5 @@ docker run \
   -e POSTGRES_USER=$(cat secrets/db.user) \
   -e POSTGRES_DB=$(cat secrets/db.name) \
   -p $(cat secrets/db.port):5432 \
-  -d postgres:13
+  -d postgres:13 \
+  postgres -N 200


### PR DESCRIPTION
Testing increase of postgres max_connections in the github actions workflow for ci runs